### PR TITLE
Dir cached nearby check for client

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -615,7 +615,6 @@ func (c *BlobCacheClient) childrenCachedNearby(ctx context.Context, id string) b
 	}
 
 	for _, child := range children {
-		Logger.Infof("child: %+v", child)
 		if child.Size == 0 {
 			if !c.childrenCachedNearby(ctx, child.ID) {
 				return false

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -615,7 +615,7 @@ func (c *BlobCacheClient) childrenCachedNearby(ctx context.Context, id string) b
 	}
 
 	for _, child := range children {
-		if child.Size == 0 {
+		if (child.Mode & fuse.S_IFDIR) != 0 {
 			if !c.childrenCachedNearby(ctx, child.ID) {
 				return false
 			}

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -596,3 +596,35 @@ func (c *BlobCacheClient) IsPathCachedNearby(ctx context.Context, path string) b
 
 	return c.IsCachedNearby(ctx, metadata.Hash)
 }
+
+func (c *BlobCacheClient) IsDirCachedNearby(ctx context.Context, path string) bool {
+	metadata, err := c.metadata.GetFsNode(ctx, GenerateFsID(path))
+	if err != nil {
+		Logger.Errorf("error getting fs node: %v, path: %s", err, path)
+		return false
+	}
+
+	return c.childrenCachedNearby(ctx, metadata.ID)
+}
+
+func (c *BlobCacheClient) childrenCachedNearby(ctx context.Context, id string) bool {
+	children, err := c.metadata.GetFsNodeChildren(ctx, id)
+	if err != nil {
+		Logger.Errorf("error getting fs node children: %v, id: %s", err, id)
+		return false
+	}
+
+	for _, child := range children {
+		if child.Size == 0 {
+			if !c.childrenCachedNearby(ctx, child.ID) {
+				return false
+			}
+		}
+
+		if !c.IsCachedNearby(ctx, child.Hash) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -615,10 +615,12 @@ func (c *BlobCacheClient) childrenCachedNearby(ctx context.Context, id string) b
 	}
 
 	for _, child := range children {
+		Logger.Infof("child: %+v", child)
 		if child.Size == 0 {
 			if !c.childrenCachedNearby(ctx, child.ID) {
 				return false
 			}
+			continue
 		}
 
 		if !c.IsCachedNearby(ctx, child.Hash) {


### PR DESCRIPTION
Resolve BE-2473

This adds a new method to check if a directory is cached nearby by recursively checking for its content. Required for https://github.com/beam-cloud/beta9/pull/1066/files